### PR TITLE
Return empty list of groups on error instead of throwing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Return empty list of groups on error instead of throwing exception ([#9](https://github.com/scm-manager/scm-ldap-plugin/pull/9))
+
 ## 2.0.0 - 2020-06-04
 ### Changed
 - Changeover to MIT license ([#3](https://github.com/scm-manager/scm-ldap-plugin/pull/3))

--- a/src/main/java/sonia/scm/auth/ldap/BindConnectionFailedException.java
+++ b/src/main/java/sonia/scm/auth/ldap/BindConnectionFailedException.java
@@ -23,10 +23,9 @@
  */
 package sonia.scm.auth.ldap;
 
-import org.apache.shiro.authc.AuthenticationException;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
-public class BindConnectionFailedException extends AuthenticationException {
+public class BindConnectionFailedException extends LdapException {
 
   public BindConnectionFailedException(String message, Throwable cause) {
     super(message, cause);

--- a/src/main/java/sonia/scm/auth/ldap/ConfigurationException.java
+++ b/src/main/java/sonia/scm/auth/ldap/ConfigurationException.java
@@ -23,10 +23,8 @@
  */
 package sonia.scm.auth.ldap;
 
-import org.apache.shiro.authc.AuthenticationException;
-
 @SuppressWarnings("squid:MaximumInheritanceDepth")
-public class ConfigurationException extends AuthenticationException {
+public class ConfigurationException extends LdapException {
 
   public ConfigurationException(String message) {
     super(message);

--- a/src/main/java/sonia/scm/auth/ldap/InvalidUserException.java
+++ b/src/main/java/sonia/scm/auth/ldap/InvalidUserException.java
@@ -23,11 +23,10 @@
  */
 package sonia.scm.auth.ldap;
 
-import org.apache.shiro.authc.AuthenticationException;
 import sonia.scm.user.User;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
-public class InvalidUserException extends AuthenticationException {
+public class InvalidUserException extends LdapException {
 
   private final User invalidUser;
 

--- a/src/main/java/sonia/scm/auth/ldap/LdapException.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapException.java
@@ -21,12 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package sonia.scm.auth.ldap;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UserAuthenticationFailedException extends LdapException {
+import org.apache.shiro.authc.AuthenticationException;
 
-  public UserAuthenticationFailedException(String message, Throwable cause) {
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class LdapException extends AuthenticationException {
+
+  public LdapException(String message) {
+    super(message);
+  }
+
+  public LdapException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/src/main/java/sonia/scm/auth/ldap/LdapGroupResolver.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapGroupResolver.java
@@ -75,7 +75,11 @@ public class LdapGroupResolver implements GroupResolver {
   public Set<String> resolve(String principal) {
     LdapConfig config = store.get();
     if (config.isEnabled()) {
-      return resolveGroups(config, principal);
+      try {
+        return resolveGroups(config, principal);
+      } catch (LdapException ex) {
+        LOG.error("failed to resolve groups for principal: {}", ex);
+      }
     } else {
       LOG.debug("ldap is disabled, returning empty set of groups");
     }

--- a/src/main/java/sonia/scm/auth/ldap/UserSearchFailedException.java
+++ b/src/main/java/sonia/scm/auth/ldap/UserSearchFailedException.java
@@ -23,10 +23,8 @@
  */
 package sonia.scm.auth.ldap;
 
-import org.apache.shiro.authc.AuthenticationException;
-
 @SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UserSearchFailedException extends AuthenticationException {
+public class UserSearchFailedException extends LdapException {
 
   public UserSearchFailedException(String message, Throwable cause) {
     super(message, cause);

--- a/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
@@ -30,7 +30,6 @@ import sonia.scm.store.InMemoryConfigurationStore;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class LdapGroupResolverTest extends LdapServerTestBaseJunit5 {
 
@@ -124,10 +123,11 @@ class LdapGroupResolverTest extends LdapServerTestBaseJunit5 {
   }
 
   @Test
-  void shouldThrowConfigurationExceptionIfBaseDNIsNotDefined() {
+  void shouldReturnEmptyOnInvalidConfiguration() {
     config.setBaseDn(null);
 
-    assertThrows(ConfigurationException.class, () -> groupResolver.resolve("trillian"));
+    Set<String> groups = groupResolver.resolve("trillian");
+    assertThat(groups).isEmpty();
   }
 
 }


### PR DESCRIPTION
## Proposed changes

After merging this pr the group resolver will catch all ldap related exceptions and log them as error. This is required because, a miss configured or a failed search can stop a start of SCM-Manager.

Fixes #8 

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
