### PR TITLE
Fix calculating corret DN for nested group search filter

### DIFF
--- a/src/test/java/sonia/scm/auth/ldap/LdapRecursiveGroupTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapRecursiveGroupTest.java
@@ -162,7 +162,7 @@ public class LdapRecursiveGroupTest extends LdapServerTestBaseJunit5 {
     ldif(13);
 
     Set<String> groups = groupResolver.resolve("trillian");
-    assertThat(groups).containsOnly("HeartOfGold", "RestaurantAtTheEndOfTheUniverse", "RestaurantsOfTheUniverse");
+    assertThat(groups).containsOnly("HeartOfGold", "RestaurantAtTheEndOfTheUniverse", "RestaurantsOfTheUniverse", "RestaurantsAtEarth");
   }
 
   @Test

--- a/src/test/resources/ldif/013.ldif
+++ b/src/test/resources/ldif/013.ldif
@@ -73,3 +73,14 @@ objectClass: groupOfUniqueNames
 uniqueMember: cn=RestaurantAtTheStartOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
 uniqueMember: cn=RestaurantAtTheEndOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
 cn: RestaurantsOfTheUniverse
+
+dn: ou=Earth,ou=Groups,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Earth
+
+dn: cn=RestaurantsAtEarth,ou=Earth,ou=Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+uniqueMember: cn=RestaurantAtTheStartOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
+uniqueMember: cn=RestaurantAtTheEndOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
+cn: RestaurantsAtEarth


### PR DESCRIPTION
## Proposed changes

This fixes a bug I discovered just now, in where the Group DN for the nested search filter (see #10) is not properly calculate in case the group is in a subdirectory. In that case, search filters using the dn of the group does not work properly.

For example, assume the simplified structure:

ou=Group
cn=Group1,ou=Group
ou=Subgroup,ou=Group
cn=Group2,ou=Subgroup,ou=Group

where Group2 is a member of Group1.

Because of poorly created DN, we assumed that the DN of Group2 is cn=Group2,ou=Group and not ou=Group,ou=Subgroup,cn=Group2. This is PR fixes this problem.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
