### PR TITLE
Use custom ssl context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Use custom ssl context ([#31](https://github.com/scm-manager/scm-ldap-plugin/pull/31))
+
 ## 2.3.0
 ### Added
 - Option to replace invalid characters in group names ([#19](https://github.com/scm-manager/scm-ldap-plugin/pull/19))
 ### Fixed
-- Calculate corret DN for nested group search filter ([#20](https://github.com/scm-manager/scm-ldap-plugin/pull/20))
+- Calculate correct DN for nested group search filter ([#20](https://github.com/scm-manager/scm-ldap-plugin/pull/20))
 
 ## 2.2.0 - 2021-03-01
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,5 @@ services:
     image: rroemhild/test-openldap
     ports:
         - "10389:10389"
+        - "10636:10636"
     privileged: true

--- a/src/main/java/sonia/scm/auth/ldap/LdapConnectionFactory.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapConnectionFactory.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sonia.scm.auth.ldap;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.util.Providers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.naming.NamingException;
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+
+public class LdapConnectionFactory {
+
+  private final Provider<SSLContext> sslContextProvider;
+
+  @Inject
+  public LdapConnectionFactory(Provider<SSLContext> sslContextProvider) {
+    this.sslContextProvider = sslContextProvider;
+  }
+
+  @VisibleForTesting
+  public LdapConnectionFactory() throws NoSuchAlgorithmException {
+    this(Providers.of(SSLContext.getDefault()));
+  }
+
+  LdapConnection createBindConnection(LdapConfig config) {
+    try {
+      return new LdapConnection(config, sslContextProvider.get(), config.getConnectionDn(), config.getConnectionPassword());
+    } catch (IOException | NamingException ex) {
+      throw new BindConnectionFailedException("failed to create bind connection for " + config.getConnectionDn(), ex);
+    }
+  }
+
+  LdapConnection createUserConnection(LdapConfig config, String userDn, String password) {
+    try {
+      return new LdapConnection(config, sslContextProvider.get(), userDn, password);
+    } catch (IOException | NamingException ex) {
+      throw new UserAuthenticationFailedException("failed to authenticate user " + userDn, ex);
+    }
+  }
+
+}

--- a/src/main/java/sonia/scm/auth/ldap/LdapRealm.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapRealm.java
@@ -55,11 +55,13 @@ public class LdapRealm extends AuthenticatingRealm {
 
   private final SyncingRealmHelper syncingRealmHelper;
   private final LdapConfigStore configStore;
+  private final LdapConnectionFactory ldapConnectionFactory;
 
   @Inject
-  public LdapRealm(LdapConfigStore configStore, SyncingRealmHelper syncingRealmHelper, CacheManager cacheManager) {
+  public LdapRealm(LdapConfigStore configStore, SyncingRealmHelper syncingRealmHelper, CacheManager cacheManager, LdapConnectionFactory ldapConnectionFactory) {
     this.configStore = configStore;
     this.syncingRealmHelper = syncingRealmHelper;
+    this.ldapConnectionFactory = ldapConnectionFactory;
     setAuthenticationTokenClass(UsernamePasswordToken.class);
     setCredentialsMatcher(new AllowAllCredentialsMatcher());
 
@@ -82,7 +84,7 @@ public class LdapRealm extends AuthenticatingRealm {
     String username = upt.getUsername();
     char[] password = upt.getPassword();
 
-    LdapAuthenticator authenticator = new LdapAuthenticator(config);
+    LdapAuthenticator authenticator = new LdapAuthenticator(ldapConnectionFactory, config);
     User user = authenticator.authenticate(username, new String(password))
       .orElseThrow(() -> new UnknownAccountException("could not find account with name " + username));
 

--- a/src/main/java/sonia/scm/auth/ldap/ThreadLocalSocketFactory.java
+++ b/src/main/java/sonia/scm/auth/ldap/ThreadLocalSocketFactory.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sonia.scm.auth.ldap;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+public class ThreadLocalSocketFactory extends SSLSocketFactory {
+
+  private static final ThreadLocal<SSLSocketFactory> delegateStore = new ThreadLocal<>();
+
+  static void setDelegate(SSLSocketFactory socketFactory) {
+    delegateStore.set(socketFactory);
+  }
+
+  @SuppressWarnings("unused")
+  public static SocketFactory getDefault() {
+    return new ThreadLocalSocketFactory();
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    return delegate.createSocket();
+  }
+
+  static void clearDelegate() {
+    delegateStore.remove();
+  }
+
+  private final SSLSocketFactory delegate;
+
+  public ThreadLocalSocketFactory() {
+    delegate = delegateStore.get();
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return delegate.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return delegate.getSupportedCipherSuites();
+  }
+
+  @Override
+  public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+    return delegate.createSocket(s, host, port, autoClose);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException {
+    return delegate.createSocket(host, port);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+    return delegate.createSocket(host, port, localHost, localPort);
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port) throws IOException {
+    return delegate.createSocket(host, port);
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+    return delegate.createSocket(address, port, localAddress, localPort);
+  }
+}

--- a/src/main/java/sonia/scm/auth/ldap/resource/LdapConfigMapper.java
+++ b/src/main/java/sonia/scm/auth/ldap/resource/LdapConfigMapper.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ObjectFactory;
 import sonia.scm.api.v2.resources.LinkBuilder;
@@ -50,6 +51,7 @@ public abstract class LdapConfigMapper {
   @Inject
   private ScmPathInfoStore scmPathInfoStore;
 
+  @Mapping(ignore = true, target = "attributes")
   public abstract LdapConfigDto map(LdapConfig config);
 
   public abstract LdapConfig map(LdapConfigDto dto, @Context LdapConfig oldConfig);

--- a/src/main/java/sonia/scm/auth/ldap/resource/LdapConfigResource.java
+++ b/src/main/java/sonia/scm/auth/ldap/resource/LdapConfigResource.java
@@ -35,6 +35,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import sonia.scm.api.v2.resources.ErrorDto;
 import sonia.scm.auth.ldap.LdapConfig;
 import sonia.scm.auth.ldap.LdapConfigStore;
+import sonia.scm.auth.ldap.LdapConnectionFactory;
 import sonia.scm.config.ConfigurationPermissions;
 import sonia.scm.user.User;
 import sonia.scm.web.VndMediaType;
@@ -64,11 +65,13 @@ public class LdapConfigResource {
 
   private final LdapConfigStore configStore;
   private final LdapConfigMapper mapper;
+  private final LdapConnectionFactory ldapConnectionFactory;
 
   @Inject
-  public LdapConfigResource(LdapConfigStore configStore, LdapConfigMapper mapper) {
+  public LdapConfigResource(LdapConfigStore configStore, LdapConfigMapper mapper, LdapConnectionFactory ldapConnectionFactory) {
     this.configStore = configStore;
     this.mapper = mapper;
+    this.ldapConnectionFactory = ldapConnectionFactory;
   }
 
   @POST
@@ -120,7 +123,7 @@ public class LdapConfigResource {
 
   @VisibleForTesting
   LdapConnectionTester createConnectionTester(LdapConfig config) {
-    return new LdapConnectionTester(config);
+    return new LdapConnectionTester(ldapConnectionFactory, config);
   }
 
   @GET

--- a/src/main/java/sonia/scm/auth/ldap/resource/LdapConnectionTester.java
+++ b/src/main/java/sonia/scm/auth/ldap/resource/LdapConnectionTester.java
@@ -28,6 +28,7 @@ import sonia.scm.auth.ldap.ConfigurationException;
 import sonia.scm.auth.ldap.InvalidUserException;
 import sonia.scm.auth.ldap.LdapAuthenticator;
 import sonia.scm.auth.ldap.LdapConfig;
+import sonia.scm.auth.ldap.LdapConnectionFactory;
 import sonia.scm.auth.ldap.LdapGroupResolver;
 import sonia.scm.auth.ldap.UserAuthenticationFailedException;
 import sonia.scm.auth.ldap.UserSearchFailedException;
@@ -39,13 +40,15 @@ import java.util.Set;
 public class LdapConnectionTester {
 
   private final LdapConfig config;
+  private final LdapConnectionFactory ldapConnectionFactory;
 
-  LdapConnectionTester(LdapConfig config) {
+  LdapConnectionTester(LdapConnectionFactory ldapConnectionFactory, LdapConfig config) {
     this.config = config;
+    this.ldapConnectionFactory = ldapConnectionFactory;
   }
 
   AuthenticationResult test(String username, String password) {
-    LdapAuthenticator authenticator = new LdapAuthenticator(config);
+    LdapAuthenticator authenticator = new LdapAuthenticator(ldapConnectionFactory, config);
     try {
       Optional<User> optionalUser = authenticator.authenticate(username, password);
 
@@ -53,7 +56,7 @@ public class LdapConnectionTester {
         return new AuthenticationResult(AuthenticationFailure.userNotFound());
       }
 
-      LdapGroupResolver groupResolver = LdapGroupResolver.from(config);
+      LdapGroupResolver groupResolver = LdapGroupResolver.from(ldapConnectionFactory, config);
       Set<String> groups = groupResolver.resolve(username);
 
       return new AuthenticationResult(optionalUser.get(), groups);

--- a/src/test/java/sonia/scm/auth/ldap/LdapAuthenticatorTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapAuthenticatorTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sonia.scm.user.User;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,9 +39,9 @@ class LdapAuthenticatorTest extends LdapServerTestBaseJunit5 {
   private LdapAuthenticator authenticator;
 
   @BeforeEach
-  void setUpAuthenticator() {
+  void setUpAuthenticator() throws NoSuchAlgorithmException {
     config = createConfig();
-    authenticator = new LdapAuthenticator(config);
+    authenticator = new LdapAuthenticator(new LdapConnectionFactory(), config);
   }
 
   @Test
@@ -128,7 +129,6 @@ class LdapAuthenticatorTest extends LdapServerTestBaseJunit5 {
   }
 
   private void assertTrillian(User user) {
-    assertThat(user.getType()).isEqualTo("ldap");
     assertThat(user.getName()).isEqualTo("trillian");
     assertThat(user.getDisplayName()).isEqualTo("Tricia McMillan");
     assertThat(user.getMail()).isEqualTo("tricia.mcmillan@hitchhiker.com");

--- a/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
@@ -23,10 +23,14 @@
  */
 package sonia.scm.auth.ldap;
 
+import com.google.inject.util.Providers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sonia.scm.store.InMemoryConfigurationStore;
 
+import javax.inject.Provider;
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,11 +41,11 @@ class LdapGroupResolverTest extends LdapServerTestBaseJunit5 {
   private LdapGroupResolver groupResolver;
 
   @BeforeEach
-  void setUpAuthenticator() {
+  void setUpAuthenticator() throws NoSuchAlgorithmException {
     config = createConfig();
     LdapConfigStore ldapConfigStore = new LdapConfigStore(new InMemoryConfigurationStore<>());
     ldapConfigStore.set(config);
-    groupResolver = new LdapGroupResolver(ldapConfigStore);
+    groupResolver = new LdapGroupResolver(ldapConfigStore, new LdapConnectionFactory());
   }
 
   @Test

--- a/src/test/java/sonia/scm/auth/ldap/LdapRealmTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapRealmTest.java
@@ -23,8 +23,6 @@
  */
 package sonia.scm.auth.ldap;
 
-//~--- non-JDK imports --------------------------------------------------------
-
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UnknownAccountException;
@@ -32,7 +30,6 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.cache.Cache;
@@ -40,17 +37,14 @@ import sonia.scm.cache.CacheManager;
 import sonia.scm.security.SyncingRealmHelper;
 import sonia.scm.user.User;
 
+import java.security.NoSuchAlgorithmException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-//~--- JDK imports ------------------------------------------------------------
-
-/**
- * @author Sebastian Sdorra
- */
 @ExtendWith(MockitoExtension.class)
 class LdapRealmTest extends LdapServerTestBaseJunit5 {
 
@@ -63,7 +57,6 @@ class LdapRealmTest extends LdapServerTestBaseJunit5 {
   @Mock
   private CacheManager cacheManager;
 
-  @InjectMocks
   private LdapRealm realm;
 
   @Mock
@@ -74,10 +67,11 @@ class LdapRealmTest extends LdapServerTestBaseJunit5 {
 
   @BeforeEach
   @SuppressWarnings("unchecked")
-  void setUpRealm() {
+  void setUpRealm() throws NoSuchAlgorithmException {
     config = createConfig();
     lenient().when(configStore.get()).thenReturn(config);
     lenient().when(cacheManager.getCache(LdapRealm.CACHE_NAME)).thenReturn(cache);
+    realm = new LdapRealm(configStore, syncingRealmHelper, cacheManager, new LdapConnectionFactory());
   }
 
   @Test
@@ -124,11 +118,11 @@ class LdapRealmTest extends LdapServerTestBaseJunit5 {
 
   @Test
   @SuppressWarnings("unchecked")
-  void shouldReturnAuthenticationInfoFromCache() {
+  void shouldReturnAuthenticationInfoFromCache() throws NoSuchAlgorithmException {
     AuthenticationToken token = createToken("trillian", "trilli123");
 
     AuthenticationInfo authenticationInfoMock = mock(AuthenticationInfo.class);
-    LdapRealm realm = new LdapRealm(configStore, syncingRealmHelper, cacheManager);
+    LdapRealm realm = new LdapRealm(configStore, syncingRealmHelper, cacheManager, new LdapConnectionFactory());
     when(cache.get("trillian")).thenReturn(authenticationInfoMock);
 
     AuthenticationInfo authenticationInfo = realm.getAuthenticationInfo(token);

--- a/src/test/java/sonia/scm/auth/ldap/LdapRecursiveGroupTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapRecursiveGroupTest.java
@@ -23,28 +23,31 @@
  */
 package sonia.scm.auth.ldap;
 
+import com.google.inject.util.Providers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import sonia.scm.store.InMemoryConfigurationStore;
 
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LdapRecursiveGroupTest extends LdapServerTestBaseJunit5 {
+class LdapRecursiveGroupTest extends LdapServerTestBaseJunit5 {
 
   private LdapConfig config;
   private LdapGroupResolver groupResolver;
 
   @BeforeEach
-  void setUpAuthenticator() {
+  void setUpAuthenticator() throws NoSuchAlgorithmException {
     config = createConfig();
     config.setEnableNestedGroups(true);
     LdapConfigStore ldapConfigStore = new LdapConfigStore(new InMemoryConfigurationStore<>());
     ldapConfigStore.set(config);
-    groupResolver = new LdapGroupResolver(ldapConfigStore);
+    groupResolver = new LdapGroupResolver(ldapConfigStore, new LdapConnectionFactory());
   }
 
   /*
@@ -174,7 +177,7 @@ public class LdapRecursiveGroupTest extends LdapServerTestBaseJunit5 {
   }
 
   @Test
-  @Timeout(value = 1, unit = TimeUnit.SECONDS)
+  @Timeout(value = 1)
   void shouldReturnGroupsFromUniqueMemberWithLoop() {
     ldif(14);
 

--- a/src/test/java/sonia/scm/auth/ldap/LdapTestBase.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapTestBase.java
@@ -23,50 +23,26 @@
  */
 package sonia.scm.auth.ldap;
 
-//~--- JDK imports ------------------------------------------------------------
-
 import java.io.IOException;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 /**
- *
  * @author Sebastian Sdorra
  */
 public class LdapTestBase {
 
-  /** Field description */
   public static final String BASE_DN = "dc=scm-manager,dc=org";
-
-  /** Field description */
   public static final String BIND_DN = "cn=Directory Manager";
-
-  /** Field description */
   public static final String BIND_PWD = "scm-manager";
-
-  /** Field description */
   public static final String HOST = "localhost";
-
-  /** Field description */
   public static final int PORT = 11389;
 
-  //~--- methods --------------------------------------------------------------
-
-  /**
-   * Method description
-   *
-   *
-   * @return
-   */
   protected LdapConfig createConfig() {
     LdapConfig config = new LdapConfig();
 
     try {
-      StringBuilder hostUrl = new StringBuilder("ldap://");
-
-      hostUrl.append(getInetAddress().getHostName());
-      hostUrl.append(":").append(String.valueOf(PORT));
       config.setEnabled(true);
       config.setBaseDn(BASE_DN);
       config.setAttributeNameId("uid");
@@ -75,7 +51,9 @@ public class LdapTestBase {
       config.setAttributeNameGroup("memberOf");
       config.setConnectionDn(BIND_DN);
       config.setConnectionPassword(BIND_PWD);
-      config.setHostUrl(hostUrl.toString());
+      String hostUrl = "ldap://" + getInetAddress().getHostName() +
+        ":" + PORT;
+      config.setHostUrl(hostUrl);
       config.setSearchFilter("(uid={0})");
       config.setSearchFilterGroup("(uniqueMember={0})");
       config.setSearchScope("sub");
@@ -88,16 +66,6 @@ public class LdapTestBase {
     return config;
   }
 
-  //~--- get methods ----------------------------------------------------------
-
-  /**
-   * Method description
-   *
-   *
-   * @return
-   *
-   * @throws UnknownHostException
-   */
   protected InetAddress getInetAddress() throws UnknownHostException {
     return InetAddress.getByName(HOST);
   }

--- a/src/test/java/sonia/scm/auth/ldap/resource/LdapConfigResourceTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/resource/LdapConfigResourceTest.java
@@ -38,9 +38,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import sonia.scm.api.v2.resources.ScmPathInfoStore;
 import sonia.scm.auth.ldap.LdapConfig;
 import sonia.scm.auth.ldap.LdapConfigStore;
+import sonia.scm.auth.ldap.LdapConnectionFactory;
 import sonia.scm.user.UserTestData;
 import sonia.scm.web.RestDispatcher;
 
+import javax.inject.Provider;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.MediaType;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -73,6 +76,8 @@ public class LdapConfigResourceTest {
   private LdapConfigStore configStore;
   @Mock
   private ScmPathInfoStore scmPathInfoStore;
+  @Mock
+  private LdapConnectionFactory ldapConnectionFactory;
 
   @Mock
   private LdapConnectionTester connectionTester;
@@ -84,7 +89,7 @@ public class LdapConfigResourceTest {
 
   @Before
   public void init() {
-    LdapConfigResource resource = new LdapConfigResource(configStore, mapper) {
+    LdapConfigResource resource = new LdapConfigResource(configStore, mapper, ldapConnectionFactory) {
       @Override
       LdapConnectionTester createConnectionTester(LdapConfig config) {
         return connectionTester;


### PR DESCRIPTION
## Proposed changes

Use custom ssl context. This is required to capture the rejected certificates which prevent the ldap connection. The rejected certificates can be administrate with the SSL-Context-Plugin.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
