### PR TITLE
Add option to exclude groups which are located outside group unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Option to exclude groups which are located outside group unit ([#33](https://github.com/scm-manager/scm-ldap-plugin/pull/33))
 ### Changed
 - Use custom ssl context ([#31](https://github.com/scm-manager/scm-ldap-plugin/pull/31))
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@
 
 
 plugins {
-  id 'org.scm-manager.smp' version '0.8.0'
+  id 'org.scm-manager.smp' version '0.8.3'
 }
 
 dependencies {

--- a/src/main/java/sonia/scm/auth/ldap/LdapConfig.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapConfig.java
@@ -109,6 +109,9 @@ public class LdapConfig implements Validateable {
   @XmlElement(name = "remove-illegal-characters")
   private boolean removeInvalidCharacters = false;
 
+  @XmlElement(name = "exclude-groups-outside-unit")
+  private boolean excludeGroupsOutsideUnit = false;
+
   public String getAttributeNameFullname() {
     return attributeNameFullname;
   }
@@ -187,6 +190,10 @@ public class LdapConfig implements Validateable {
 
   public boolean isRemoveInvalidCharacters() {
     return removeInvalidCharacters;
+  }
+
+  public boolean isExcludeGroupsOutsideUnit() {
+    return excludeGroupsOutsideUnit;
   }
 
   public boolean isEnabled() {
@@ -281,6 +288,10 @@ public class LdapConfig implements Validateable {
 
   public void setRemoveInvalidCharacters(boolean removeInvalidCharacters) {
     this.removeInvalidCharacters = removeInvalidCharacters;
+  }
+
+  public void setExcludeGroupsOutsideUnit(boolean excludeGroupsOutsideUnit) {
+    this.excludeGroupsOutsideUnit = excludeGroupsOutsideUnit;
   }
 
   private boolean isValid(String... fields) {

--- a/src/main/java/sonia/scm/auth/ldap/LdapGroupResolver.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapGroupResolver.java
@@ -134,7 +134,7 @@ public class LdapGroupResolver implements GroupResolver {
       String groupsUnit = LdapUtil.createDN(config, config.getUnitGroup()).toLowerCase(Locale.ENGLISH);
       return dn -> {
         String parent = LdapUtil.getParentDN(dn).toLowerCase(Locale.ENGLISH);
-        return parent.startsWith(groupsUnit);
+        return parent.endsWith(groupsUnit);
       };
     }
     return dn -> true;

--- a/src/main/java/sonia/scm/auth/ldap/LdapGroupResolver.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapGroupResolver.java
@@ -39,15 +39,21 @@ import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
-import javax.net.ssl.SSLContext;
-import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toSet;
-import static sonia.scm.auth.ldap.LdapUtil.*;
+import static sonia.scm.auth.ldap.LdapUtil.close;
+import static sonia.scm.auth.ldap.LdapUtil.getAttribute;
 
 @Extension
 public class LdapGroupResolver implements GroupResolver {
@@ -113,10 +119,25 @@ public class LdapGroupResolver implements GroupResolver {
         if(config.isEnableNestedGroups()){
           groups = computeRecursiveGroups(bindConnection, groups);
         }
-        return groups.stream().map(LdapUtil::getName).collect(Collectors.toSet());
+        Predicate<String> unitFilter = unitFilter(config);
+        return groups.stream()
+          .filter(unitFilter)
+          .map(LdapUtil::getName)
+          .collect(Collectors.toSet());
       }
     }
     return Collections.emptySet();
+  }
+
+  private Predicate<String> unitFilter(LdapConfig config) {
+    if (config.isExcludeGroupsOutsideUnit() && !Strings.isNullOrEmpty(config.getUnitGroup())) {
+      String groupsUnit = LdapUtil.createDN(config, config.getUnitGroup()).toLowerCase(Locale.ENGLISH);
+      return dn -> {
+        String parent = LdapUtil.getParentDN(dn).toLowerCase(Locale.ENGLISH);
+        return parent.startsWith(groupsUnit);
+      };
+    }
+    return dn -> true;
   }
 
   private Set<String> computeRecursiveGroups(LdapConnection connection, Set<String> groups) {

--- a/src/main/java/sonia/scm/auth/ldap/LdapUtil.java
+++ b/src/main/java/sonia/scm/auth/ldap/LdapUtil.java
@@ -206,6 +206,14 @@ class LdapUtil {
     return name;
   }
 
+  public static String getParentDN(String dn) {
+    int index = dn.indexOf(',');
+    if (index > 0) {
+      return dn.substring(index + 1);
+    }
+    return dn;
+  }
+
 
   /**
    * Method description

--- a/src/main/java/sonia/scm/auth/ldap/resource/LdapConfigDto.java
+++ b/src/main/java/sonia/scm/auth/ldap/resource/LdapConfigDto.java
@@ -62,6 +62,7 @@ public class LdapConfigDto extends HalRepresentation {
   private boolean enableNestedADGroups;
   private boolean enableNestedGroups;
   private boolean removeInvalidCharacters;
+  private boolean excludeGroupsOutsideUnit;
 
   public LdapConfigDto(Links links) {
     super(links);

--- a/src/main/js/LdapConfigurationForm.tsx
+++ b/src/main/js/LdapConfigurationForm.tsx
@@ -47,6 +47,7 @@ type LdapConfiguration = {
   enableNestedGroups: boolean;
   enableNestedADGroups: boolean;
   enableStartTls: boolean;
+  excludeGroupsOutsideUnit: boolean;
   removeInvalidCharacters: boolean;
   enabled: boolean;
 };
@@ -160,6 +161,7 @@ class LdapConfigurationForm extends React.Component<Props, State> {
           {this.createCheckbox("enableNestedADGroups")}
           {this.createCheckbox("enableStartTls")}
           {this.createCheckbox("removeInvalidCharacters")}
+          {this.createCheckbox("excludeGroupsOutsideUnit")}
           {this.createCheckbox("enabled")}
         </div>
         <div className="column is-full">

--- a/src/main/js/profiles.ts
+++ b/src/main/js/profiles.ts
@@ -35,6 +35,7 @@ export const PROFILES = {
     unitGroup: "",
     enableNestedADGroups: true,
     enableNestedGroups: false,
+    excludeGroupsOutsideUnit: false,
     referralStrategy: "FOLLOW"
   },
   Apache: {
@@ -50,6 +51,7 @@ export const PROFILES = {
     unitGroup: "ou=Groups",
     enableNestedADGroups: false,
     enableNestedGroups: false,
+    excludeGroupsOutsideUnit: false,
     referralStrategy: "FOLLOW"
   },
   OpenDJ: {
@@ -65,6 +67,7 @@ export const PROFILES = {
     unitGroup: "ou=Groups",
     enableNestedADGroups: false,
     enableNestedGroups: false,
+    excludeGroupsOutsideUnit: false,
     referralStrategy: "FOLLOW",
   },
   OpenLDAP: {
@@ -80,6 +83,7 @@ export const PROFILES = {
     unitGroup: "ou=Groups",
     enableNestedADGroups: false,
     enableNestedGroups: false,
+    excludeGroupsOutsideUnit: false,
     referralStrategy: "FOLLOW"
   },
   posix: {
@@ -95,6 +99,7 @@ export const PROFILES = {
     unitGroup: "ou=Groups",
     enableNestedADGroups: false,
     enableNestedGroups: false,
+    excludeGroupsOutsideUnit: false,
     referralStrategy: "FOLLOW"
   },
   sun: {
@@ -110,6 +115,7 @@ export const PROFILES = {
     unitGroup: "ou=Groups",
     enableNestedADGroups: false,
     enableNestedGroups: false,
+    excludeGroupsOutsideUnit: false,
     referralStrategy: "FOLLOW"
   },
   Custom: {}

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -43,6 +43,8 @@
       "enableStartTlsHelp": "Verwende StartTLS Erweiterung um eine verschlüsselte Verbindung zum DirecotryServer aufzubauen.",
       "removeInvalidCharacters": "Ungültige Zeichen im Gruppennamen ersetzen",
       "removeInvalidCharactersHelp": "Ungültige Zeichen im Gruppennamen wie '/', '&', '?' oder Leerzeichen werden mit einem Unterstrich ('_') ersetzt.",
+      "excludeGroupsOutsideUnit": "Verwende nur Gruppen aus dem Gruppen-Pfad",
+      "excludeGroupsOutsideUnitHelp": "Entfernt alle Gruppen aus dem Ergebnis die nicht aus dem Gruppen-Pfad kommen, auch wenn das Gruppen Attribut Gruppen aus anderen Pfaden zurückliefert.",
       "enabled": "Aktiviert",
       "enabledHelp": "Aktiviert / Deaktiviert die LDAP Authentifizierung",
       "options": {

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -43,6 +43,8 @@
       "enableStartTlsHelp": "Use StartTLS extension to encrypt the connection to the directory server.",
       "removeInvalidCharacters": "Replace invalid characters in group names",
       "removeInvalidCharactersHelp": "Invalid characters in group names like '/', '&', '?' or spaces will be replaces with an underscore ('_').",
+      "excludeGroupsOutsideUnit": "Exclude groups outside of groups unit",
+      "excludeGroupsOutsideUnitHelp": "Removes all groups which are located outside of the configured groups unit, even if the group attribute contains such groups.",
       "enabled": "Enabled",
       "enabledHelp": "Enables or disables the ldap authentication.",
       "options": {

--- a/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
@@ -159,4 +159,14 @@ class LdapGroupResolverTest extends LdapServerTestBaseJunit5 {
     Set<String> groups = groupResolver.resolve("trillian");
     assertThat(groups).containsOnly("HappyVerticalPeopleTransporter");
   }
+
+  @Test
+  void shouldResolveOnlyGroupsOfUnitFromSubTree() {
+    config.setExcludeGroupsOutsideUnit(true);
+    config.setUnitGroup("ou=Other Groups");
+    ldif(17);
+
+    Set<String> groups = groupResolver.resolve("trillian");
+    assertThat(groups).containsOnly("Happy Vertical People Transporter");
+  }
 }

--- a/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapGroupResolverTest.java
@@ -23,13 +23,10 @@
  */
 package sonia.scm.auth.ldap;
 
-import com.google.inject.util.Providers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sonia.scm.store.InMemoryConfigurationStore;
 
-import javax.inject.Provider;
-import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 
@@ -141,5 +138,25 @@ class LdapGroupResolverTest extends LdapServerTestBaseJunit5 {
 
     Set<String> groups = groupResolver.resolve("trillian");
     assertThat(groups).containsOnly("hg_HeartOfGold", "hg_RestaurantAtTheEndOfTheUniverse", "Happy_Vertical_People_Transporter");
+  }
+
+  @Test
+  void shouldResolveOnlyGroupsOfUnitFromAttribute() {
+    config.setExcludeGroupsOutsideUnit(true);
+    config.setUnitGroup("ou=Other Groups");
+    ldif(15);
+
+    Set<String> groups = groupResolver.resolve("trillian");
+    assertThat(groups).containsOnly("Happy Vertical People Transporter");
+  }
+
+  @Test
+  void shouldResolveOnlyGroupsOfUnitFromSearchFilter() {
+    config.setExcludeGroupsOutsideUnit(true);
+    config.setUnitGroup("ou=Other Groups");
+    ldif(16);
+
+    Set<String> groups = groupResolver.resolve("trillian");
+    assertThat(groups).containsOnly("HappyVerticalPeopleTransporter");
   }
 }

--- a/src/test/resources/ldif/016.ldif
+++ b/src/test/resources/ldif/016.ldif
@@ -1,0 +1,62 @@
+version: 1
+
+dn: dc=scm-manager,dc=org
+objectClass: domain
+objectClass: top
+dc: scm-manager
+
+dn: ou=People,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: People
+
+dn: uid=trillian,ou=People,dc=scm-manager,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Tricia McMillan
+sn: McMillan
+givenName: Tricia
+uid: trillian
+userPassword: trilli123
+mail: tricia.mcmillan@hitchhiker.com
+
+dn: uid=zaphod,ou=People,dc=scm-manager,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Zaphod Beeblebrox
+sn: Beeblebrox
+givenName: Zaphod
+uid: zaphod
+userPassword: zaphod123
+mail: zaphod.beeblebrox@hitchhiker.com
+
+dn: ou=Groups,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: cn=HeartOfGold,ou=Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+uniqueMember: uid=trillian,ou=People,dc=scm-manager,dc=org
+cn: HeartOfGold
+
+dn: cn=RestaurantAtTheEndOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+uniqueMember: uid=trillian,ou=People,dc=scm-manager,dc=org
+uniqueMember: uid=zaphod,ou=People,dc=scm-manager,dc=org
+cn: RestaurantAtTheEndOfTheUniverse
+
+dn: ou=Other Groups,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: cn=HappyVerticalPeopleTransporter,ou=Other Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+uniqueMember: uid=trillian,ou=People,dc=scm-manager,dc=org
+cn: HappyVerticalPeopleTransporter
+

--- a/src/test/resources/ldif/017.ldif
+++ b/src/test/resources/ldif/017.ldif
@@ -1,0 +1,54 @@
+version: 1
+
+dn: dc=scm-manager,dc=org
+objectClass: domain
+objectClass: top
+dc: scm-manager
+
+dn: ou=People,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: People
+
+dn: uid=trillian,ou=People,dc=scm-manager,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Tricia McMillan
+sn: McMillan
+givenName: Tricia
+uid: trillian
+userPassword: trilli123
+mail: tricia.mcmillan@hitchhiker.com
+memberOf: cn=hg/HeartOfGold,ou=Groups,dc=scm-manager,dc=org
+memberOf: cn=hg/RestaurantAtTheEndOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
+memberOf: cn=Happy Vertical People Transporter,ou=stuff,ou=Other Groups,dc=scm-manager,dc=org
+
+dn: ou=Groups,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: cn=hg/HeartOfGold,ou=Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+cn: HeartOfGold
+
+dn: cn=hg/RestaurantAtTheEndOfTheUniverse,ou=Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+cn: RestaurantAtTheEndOfTheUniverse
+
+dn: ou=Other Groups,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: ou=stuff,ou=Other Groups,dc=scm-manager,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: stuff
+
+dn: cn=Happy Vertical People Transporter,ou=stuff,ou=Other Groups,dc=scm-manager,dc=org
+objectClass: groupOfUniqueNames
+cn: HappyVerticalPeopleTransporter
+


### PR DESCRIPTION
## Proposed changes

Make resolving of groups more configurable by adding an option to exclude groups which are located outside of the configured group unit. By default the ldap plugin will return all groups which are found in the group attribute of the user (e.g.: memberOf attribute), this includes groups which are outside of the groups unit (e.g.: ou=Groups). The new option will ensure that only groups are returned which are located under the group unit.

We've decided to create an option for the behaviour to not break existing installations. The option is only available if the custom profile is selected.

Fixes #22 and #14

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
