### PR TITLE
Cache invalid credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@
  */
 
 plugins {
-  id 'org.scm-manager.smp' version '0.10.1'
+  id 'org.scm-manager.smp' version '0.11.1'
 }
 
 dependencies {

--- a/gradle/changelog/cache_invalid_credentials.yaml
+++ b/gradle/changelog/cache_invalid_credentials.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Cache invalid credentials ([#50](https://github.com/scm-manager/scm-ldap-plugin/pull/50))

--- a/src/main/java/sonia/scm/auth/ldap/InvalidCredentialsCache.java
+++ b/src/main/java/sonia/scm/auth/ldap/InvalidCredentialsCache.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package sonia.scm.auth.ldap;
 
 import com.google.inject.Inject;

--- a/src/main/java/sonia/scm/auth/ldap/InvalidCredentialsCache.java
+++ b/src/main/java/sonia/scm/auth/ldap/InvalidCredentialsCache.java
@@ -1,0 +1,74 @@
+package sonia.scm.auth.ldap;
+
+import com.google.inject.Inject;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import sonia.scm.cache.Cache;
+import sonia.scm.cache.CacheManager;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+class InvalidCredentialsCache {
+
+  private final Cache<UsernamePasswordKey, Object> cache;
+  private final MessageDigest passwordCacheDigest;
+
+  @Inject
+  InvalidCredentialsCache(CacheManager cacheManager) throws NoSuchAlgorithmException {
+    this.cache = cacheManager.getCache("sonia.scm.ldap.invalidCredentials");
+    this.passwordCacheDigest = MessageDigest.getInstance("SHA-256");
+  }
+
+  void verifyNotInvalid(UsernamePasswordToken token) {
+    if (cache.contains(new UsernamePasswordKey(token))) {
+      throw new AuthenticationException("this is known to be wrong");
+    }
+  }
+
+  void cacheAsInvalid(UsernamePasswordToken upt) {
+    cache.put(new UsernamePasswordKey(upt), new Object());
+  }
+
+  private class UsernamePasswordKey {
+    private final String username;
+    private final byte[] password;
+
+    private UsernamePasswordKey(UsernamePasswordToken token) {
+      this.username = token.getUsername();
+      this.password = passwordCacheDigest.digest(toBytes(token.getPassword()));
+    }
+
+    private byte[] toBytes(char[] chars) {
+      CharBuffer charBuffer = CharBuffer.wrap(chars);
+      ByteBuffer byteBuffer = UTF_8.encode(charBuffer);
+      byte[] bytes = Arrays.copyOfRange(byteBuffer.array(),
+        byteBuffer.position(), byteBuffer.limit());
+      Arrays.fill(byteBuffer.array(), (byte) 0); // clear sensitive data
+      return bytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+
+      if (!(o instanceof UsernamePasswordKey)) return false;
+
+      UsernamePasswordKey that = (UsernamePasswordKey) o;
+
+      return new EqualsBuilder().append(username, that.username).append(password, that.password).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+      return new HashCodeBuilder(17, 37).append(username).append(password).toHashCode();
+    }
+  }
+}

--- a/src/main/resources/META-INF/scm/gcache.xml
+++ b/src/main/resources/META-INF/scm/gcache.xml
@@ -31,5 +31,11 @@
     expireAfterAccess="60"
     expireAfterWrite="120"
   />
+  <cache
+    name="sonia.scm.ldap.invalidCredentials"
+    maximumSize="1000"
+    expireAfterAccess="2"
+    expireAfterWrite="5"
+  />
 
 </caches>

--- a/src/test/java/sonia/scm/auth/ldap/InvalidCredentialsCacheTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/InvalidCredentialsCacheTest.java
@@ -1,0 +1,60 @@
+package sonia.scm.auth.ldap;
+
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.cache.Cache;
+import sonia.scm.cache.CacheManager;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InvalidCredentialsCacheTest {
+
+  @Mock
+  private CacheManager cacheManager;
+  @Mock
+  private Cache<Object, Object> cache;
+  private final Map<Object, Object> cacheBackend = new HashMap<>();
+  private InvalidCredentialsCache invalidCredentialsCache;
+
+
+  @BeforeEach
+  void setUpCache() throws NoSuchAlgorithmException {
+    when(cacheManager.getCache("sonia.scm.ldap.invalidCredentials"))
+      .thenReturn(cache);
+    lenient().when(cache.contains(any()))
+      .thenAnswer(invocation -> cacheBackend.containsKey(invocation.getArgument(0)));
+    lenient().when(cache.put(any(), any()))
+      .thenAnswer(invocation -> cacheBackend.put(invocation.getArgument(0), invocation.getArgument(1)));
+    invalidCredentialsCache = new InvalidCredentialsCache(cacheManager);
+  }
+
+  @Test
+  void shouldCacheInvalidCredentials() {
+    UsernamePasswordToken token = new UsernamePasswordToken("trillian", "incorrect");
+    invalidCredentialsCache.cacheAsInvalid(token);
+
+    Assert.assertThrows(AuthenticationException.class, () -> invalidCredentialsCache.verifyNotInvalid(token));
+  }
+
+  @Test
+  void shouldIgnoreUnknownCredentials() {
+    UsernamePasswordToken token = new UsernamePasswordToken("trillian", "incorrect");
+    invalidCredentialsCache.cacheAsInvalid(token);
+
+    UsernamePasswordToken otherToken = new UsernamePasswordToken("trillian", "unknown");
+    invalidCredentialsCache.verifyNotInvalid(otherToken);
+  }
+}

--- a/src/test/java/sonia/scm/auth/ldap/InvalidCredentialsCacheTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/InvalidCredentialsCacheTest.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package sonia.scm.auth.ldap;
 
 import org.apache.shiro.authc.AuthenticationException;

--- a/src/test/java/sonia/scm/auth/ldap/LdapRealmTest.java
+++ b/src/test/java/sonia/scm/auth/ldap/LdapRealmTest.java
@@ -45,7 +45,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LdapRealmTest extends LdapServerTestBaseJunit5 {
@@ -157,7 +162,8 @@ class LdapRealmTest extends LdapServerTestBaseJunit5 {
 
   @Test
   void shouldCacheInvalidCredential() {
-    UsernamePasswordToken token = createToken("trillian", "trilli123");
+    ldif(1);
+    UsernamePasswordToken token = createToken("arthur", "trilli123");
 
     assertThrows(AuthenticationException.class, () -> realm.getAuthenticationInfo(token));
 


### PR DESCRIPTION
## Proposed changes

The LDAP plugin caches successful logins, so that using
valid credentials, concrete requests against the LDAP server
are reduced. This is especially important for Subversion,
because a simple commit consists of multiple requests that
should not all be checked using the LDAP server.
But: this only works for successful requests out of the box.
With invalid credentials, a new request is made for every
single request. While this is not that problematic with manual
requests with a mistyped password, this might lead to an
amount of requests when the user has created an api key.
Doing so, the SCM-Manager will still check all realms,
including LDAP. So, a simple SVN commit with an API key can
lead to a not negligible amount of requests to the LDAP.
To avoid this, we introduce a further cache, that keeps
credentials rejected by the LDAP server for some time
(currently 5 seconds) and does not bother the server again,
while this one is cached. The (unknown) password is kept as
a sha256 hash in this cache, to avoid it being flushed to
disk with another cache configuration.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
